### PR TITLE
Support 7z, logfiles and skip disabled repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,21 @@ For this backup script you'll only need to generate a PAT with read access on Co
 
 ### Launch script
 
-    ./backup-azure-devops-repository.ps1 -Organization 'DEVOPS_ORG_URL' -PAT DEVOPS_PAT -BackupDir 'BACKUP_DIRECTORY' -DryRun $true 
+    ./backup-azure-devops-repository.ps1 -Organization 'DEVOPS_ORG_URL' -PAT DEVOPS_PAT -BackupDir 'BACKUP_DIRECTORY' -DryRun 
 
     Parameters:
        -o | -Organization: 
             The azure devops organisation URL (eg: https://dev.azure.com/my-company)
+            If you only have one location you can set it as default for the parameter
        -d | -BackupDir: 
             The directory where to store the backup archive.
+            You can specify a default for this parameter in the code
        -p | -PAT: The Personnal Access Token (PAT) that you need to generate for your Azure Devops Account
-       -x | -DryRun: true/false - If you want to create a dummy file instead of cloning the repositories
-       -r | -RetentionDays 7 - Retention in days
+       -f | -RepoFilter: Specify a name filter to include only matching repositories (default = *)
+       -l | -LogFile: specify a transcript log file. Path based on current folder
+            fe: -LogFile "C:\Temp\DevopsBackup_$(Get-Date -f 'yyyyMMdd_HHmm').log"
+       -c | -CompressMethod: Specify to use 7z or builtin zip compression (default = 7z)
+            If 7z is installed at non standard location update the location in the code. To install run 'winget install 7zip.7zip'
+            if 7z is specified but not found internal zip is used. (Be aware the buildin zip only supports archives up to 2Gb.)
+       -x | -DryRun - If you want to create a dummy file instead of cloning the repositories specify -DryRun
+       -r | -RetentionDays 7 - Retention in days before archives are removed. (0=never)

--- a/backup-azure-devops-repository.ps1
+++ b/backup-azure-devops-repository.ps1
@@ -18,32 +18,48 @@
 #>
 
 param(
-   [Parameter(Mandatory, HelpMessage="The azure devops organisation URL (eg: https://dev.azure.com/my-company)")]
+   [Parameter(HelpMessage="The azure devops organisation URL (eg: https://dev.azure.com/my-company)")]
+   [ValidateNotNullOrEmpty()]
    [Alias('o')]
-   [string]$Organization,
+   [string]$Organization='',
 
-   [Parameter(Mandatory, HelpMessage="The directory where to store the backup archive. eg: C:/Backup/")]
+   [Parameter(HelpMessage="The directory where to store the backup archive. eg: C:/Backup/")]
+   [ValidateNotNullOrEmpty()]
    [Alias('d')]
-   [string]$BackupDir,
+   [string]$BackupDir='',
 
    [Parameter(Mandatory, HelpMessage="The Personal Access Token (PAT) that you need to generate for your Azure Devops Account")]
    [Alias('p')]
    [string]$PAT,
 
+   [Parameter(HelpMessage="Include only repositories matching the filter")]
+   [Alias('f')]
+   [string]$RepoFilter='*',
+
    [Parameter(HelpMessage="Writes an transcript log to given file")]
    [Alias('l')]
-   [string]$logfile,
+   [string]$LogFile,
 
-   [Parameter()]
+   [Parameter(HelpMessage="What tool to use to compress the result (7z/zip)")]
+   [Alias('c')]
+   [ValidateSet('7z', 'zip')]
+   [string]$CompressMethod='7z',
+
+   [Parameter(HelpMessage="How many days to keep the backup archives before deleting them (0=never)")]
    [Alias('r')]
    [int]$RetentionDays,
 
    [Parameter(HelpMessage="If you want to create a dummy file instead of cloning the repositories")]
    [Alias('x')]
-   [bool]$DryRun = $false
+   [switch]$DryRun = $false
 )
 
-if ($logfile) { Start-Transcript $logfile}
+#Skip repositories that are disabled (and will likely fail), set to $false to try to include
+$SkipDisabledRepos=$true
+#Location of the 7z.exe file
+$7zexe='C:\Program Files\7-Zip\7z.exe'
+
+if ($logfile) { Start-Transcript $LogFile}
 
 Write-Host "=== Script parameters"
 Write-Host "ORGANIZATION_URL  = $Organization"
@@ -51,8 +67,18 @@ Write-Host "BACKUP_ROOT_PATH  = $BackupDir"
 Write-Host "RETENTION_DAYS    = $RetentionDays"
 Write-Host "DRY_RUN           = $DryRun"
 
-#Store script start time
+#Store script start time and current folder
 $startTime = Get-Date
+$curdir=Get-Location
+
+#Test if 7z is available, fallback to zip if not
+if ($CompressMethod -ieq '7z') {
+   if (!(Test-Path -Path  $7zexe -PathType Leaf)) {
+      Write-Warning "$7zexe could not be located! If installed at a different location adjust in the code.`nTo install 7zip run 'winget install 7zip.7zip'"
+      Write-Output 'Using build-in zip compression instead'
+      $CompressMethod='zip'
+   }
+}
 
 #Install Azure CLI on Windows
 #Write-Host "=== Install Azure CLI"
@@ -71,8 +97,9 @@ $projectList = az devops project list --organization $Organization --query 'valu
 
 #Create backup folder with current time as name
 $backupFolder= Get-Date -Format "yyyyMMddHHmm"
-$backupDirectory="$BackupDir$backupFolder"
-New-Item -Path $backupDirectory -ItemType Directory
+$backupName = Get-Date -Format "yyyy-MM-dd_HH-mm"
+$backupDirectory= Join-Path -Path $BackupDir -ChildPath $backupFolder
+New-Item -Path $backupDirectory -ItemType Directory | Out-Null
 Set-Location $backupDirectory
 Write-Host "=== Backup folder created [${backupDirectory}]"
 
@@ -80,14 +107,14 @@ Write-Host "=== Backup folder created [${backupDirectory}]"
 $projectCounter=0
 $repoCounter=0
 
-foreach ($project in $projectList) {
+foreach ($project in ($projectList | Where-Object {$_.Name -ilike $RepoFilter})) {
 
 
    Write-Host "==> Backup project [${projectCounter}] [$($project.name)] [$($project.id)]"
 
    #Get current project name
    $currentProjectName=$($project.name)
-   New-Item -Path "$backupDirectory/$currentProjectName" -ItemType Directory
+   New-Item -Path "$backupDirectory/$currentProjectName" -ItemType Directory | Out-Null
    Set-Location "$backupDirectory/$currentProjectName"
    Get-Location
 
@@ -107,7 +134,7 @@ foreach ($project in $projectList) {
          $repo | ConvertTo-Json >> "$currentRepoName-definition.json"
       }
       else {
-         if ($repo.isDisabled) {
+         if ($repo.isDisabled -and $SkipDisabledRepos) {
             Write-Host "====> Skipping disabled repo: [$($repo.name)]"
          } else {
             git -c http.extraHeader="Authorization: Basic $B64Pat" clone $($repo.webUrl) $currentRepoDirectory
@@ -123,18 +150,19 @@ foreach ($project in $projectList) {
 #Backup summary
 $endTime= Get-Date
 $elapsed=$endTime-$startTime
-$backupSizeUncompressed= "{0:N2}" -f ((Get-ChildItem -path $backupDirectory -recurse | Measure-Object -property length -sum ).sum /1MB) + "MB"
+$backupSizeUncompressed= "{0:N2}" -f ((Get-ChildItem -path $backupDirectory -Recurse -Force | Measure-Object -property length -sum ).sum /1MB) + "MB"
 
 Set-Location $backupDirectory
 Write-Host "=== Compress folder"
-if (Test-Path -Path 'C:\Program Files\7-Zip\7z.exe' -PathType Leaf) {
+if ($CompressMethod -ieq '7z') {
    # Use 7-zip to compress the files when available
-   & 'C:\Program Files\7-Zip\7z.exe' a -r -sdel -mx9 -y "$backupFolder.7z"  .
-   $backupSizeCompressed="{0:N2}" -f ((Get-ChildItem "$backupFolder.7z" | Measure-Object -property length -sum ).sum /1MB) + "MB"
+   & $7zexe a -r -sdel -mx9 -y "$backupName.7z"  .
+   $backupSizeCompressed="{0:N2}" -f ((Get-ChildItem "$backupName.7z" | Measure-Object -property length -sum ).sum /1MB) + "MB"
 } else {
-   # Use default builtin command. Might skip hidden folders like .git 
-   Compress-Archive -Path . -DestinationPath "$backupFolder.zip" -CompressionLevel Optimal
-   $backupSizeCompressed="{0:N2}" -f ((Get-ChildItem $backupFolder.zip | Measure-Object -property length -sum ).sum /1MB) + "MB"
+   # Use default builtin command. First unhide all hidden files/folders so they will be included as well.
+   Get-ChildItem -Path . -Recurse -Hidden -Force | ForEach-Object { $_.Attributes -= 'Hidden' }
+   Compress-Archive -Path . -DestinationPath "$backupName.zip" -CompressionLevel Optimal
+   $backupSizeCompressed="{0:N2}" -f ((Get-ChildItem $backupName.zip | Measure-Object -property length -sum ).sum /1MB) + "MB"
    Write-Host "=== Remove raw data in folder"
    Get-ChildItem -Directory | Remove-Item -Force -Recurse
 }
@@ -155,3 +183,4 @@ else
    Get-ChildItem $BackupDir -Recurse -Force -Directory  | Where-Object {$_.CreationTime -le $(get-date).Adddays(-$RetentionDays)} | Remove-Item -Force -Recurse
 }
 if ($logfile) { Stop-Transcript }
+Set-Location $curdir


### PR DESCRIPTION
Support 7z, logfiles and skip disabled repos
7z because it also supports hidden files/folders and has a better compression
logfiles for automated runs
and skip disabled repos to avoid errors if you have a lot of them....